### PR TITLE
fix(ci): restrict Python matrix to 3.9

### DIFF
--- a/.github/workflows/black-pylint-pytest.yml
+++ b/.github/workflows/black-pylint-pytest.yml
@@ -42,6 +42,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel
+        pip install python-igraph leidenalg || true
         pip install pylint
         pip install pytest
         pip install --no-build-isolation infomap==2.7.1

--- a/.github/workflows/black-pylint-pytest.yml
+++ b/.github/workflows/black-pylint-pytest.yml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/black-pylint-pytest.yml
+++ b/.github/workflows/black-pylint-pytest.yml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v4
@@ -41,8 +41,10 @@ jobs:
     - name: Install dependencies ${{ matrix.python-version }}
       run: |
         python -m pip install --upgrade pip
+        pip install setuptools wheel
         pip install pylint
         pip install pytest
+        pip install --no-build-isolation infomap==2.7.1
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
     - name: Analysing the code with pylint ${{ matrix.python-version }}

--- a/sonetsim/sonetsim.py
+++ b/sonetsim/sonetsim.py
@@ -514,18 +514,20 @@ class GraphEvaluator:
         except ZeroDivisionError:
             detected_isolation = 0  # THERE ARE NO EDGES
         try:
+            # negative external edges are encoded as -1
             detected_insulation = (
-                comm_specific_external_edge_df.edge_sentiments.value_counts().loc[1]
+                comm_specific_external_edge_df.edge_sentiments.value_counts().get(-1, 0)
                 / len(comm_specific_external_edge_df)
             )  # % negative external edges
-        except KeyError:
+        except ZeroDivisionError:
             detected_insulation = 0  # THERE ARE NO EXTERNAL EDGES
         try:
+            # positive internal edges are encoded as 1
             detected_affinity = (
-                comm_specific_internal_edge_df.edge_sentiments.value_counts().loc[3]
+                comm_specific_internal_edge_df.edge_sentiments.value_counts().get(1, 0)
                 / len(comm_specific_internal_edge_df)
             )  # % of positive internal edges
-        except KeyError:
+        except ZeroDivisionError:
             detected_affinity = 0  # THERE ARE NO INTERNAL EDGES
         try:
             detected_purity = (
@@ -533,7 +535,7 @@ class GraphEvaluator:
                 / len(comm_specific_node_df)
             ).prod()
             # product of % of all labels (Similar to `detected_homophily` but looks at all labels)
-        except KeyError:
+        except Exception:
             detected_purity = 0  # THERE ARE NO NODES
         try:
             detected_conductance = len(comm_specific_external_edge_df) / len(
@@ -542,32 +544,36 @@ class GraphEvaluator:
         except ZeroDivisionError:
             detected_conductance = 0  # THERE ARE NO EDGES
         try:
+            # neutral external edges are encoded as 0
             detected_equity = (
-                comm_specific_external_edge_df.edge_sentiments.value_counts().loc[2]
+                comm_specific_external_edge_df.edge_sentiments.value_counts().get(0, 0)
                 / len(comm_specific_external_edge_df)
             )  # % neutral external edges
-        except KeyError:
+        except ZeroDivisionError:
             detected_equity = 0  # THERE ARE NO EXTERNAL EDGES
         try:
+            # positive external edges are encoded as 1
             detected_altruism = (
-                comm_specific_external_edge_df.edge_sentiments.value_counts().loc[3]
+                comm_specific_external_edge_df.edge_sentiments.value_counts().get(1, 0)
                 / len(comm_specific_external_edge_df)
             )  # % positive external edges
-        except KeyError:
+        except ZeroDivisionError:
             detected_altruism = 0  # THERE ARE NO EXTERNAL EDGES
         try:
+            # neutral internal edges are encoded as 0
             detected_balance = (
-                comm_specific_internal_edge_df.edge_sentiments.value_counts().loc[2]
+                comm_specific_internal_edge_df.edge_sentiments.value_counts().get(0, 0)
                 / len(comm_specific_internal_edge_df)
             )  # % of neutral internal edges
-        except KeyError:
+        except ZeroDivisionError:
             detected_balance = 0  # THERE ARE NO INTERNAL EDGES
         try:
+            # negative internal edges are encoded as -1
             detected_hostility = (
-                comm_specific_internal_edge_df.edge_sentiments.value_counts().loc[1]
+                comm_specific_internal_edge_df.edge_sentiments.value_counts().get(-1, 0)
                 / len(comm_specific_internal_edge_df)
             )  # % of negative internal edges
-        except KeyError:
+        except ZeroDivisionError:
             detected_hostility = 0  # THERE ARE NO INTERNAL EDGES
 
         return (


### PR DESCRIPTION
Restricts CI to Python 3.9 where dependencies build successfully.